### PR TITLE
Remove all of the built-in format tokens - these are included by c-icap,...

### DIFF
--- a/src/squidclamav.h
+++ b/src/squidclamav.h
@@ -123,84 +123,9 @@ int load_patterns(void);
     ci_debug_printf(LEVEL, "%s(%d) %s: ", __FILE__, __LINE__, __FUNCTION__); \
     ci_debug_printf(LEVEL, ARGS)
 
-// everything from here down with exception to fmt_malware, is from c-icap, in
-// txt_format.c. None if it is in a header. So it must be defined here.
-
-int fmt_none(ci_request_t *req_data, char *buf,int len, const char *param);
-int fmt_percent(ci_request_t *req_data, char *buf,int len, const char *param);
-int fmt_remoteip(ci_request_t *req_data, char *buf,int len, const char *param);
-int fmt_localip(ci_request_t *req_data, char *buf,int len, const char *param);
-int fmt_icapstatus(ci_request_t *req_data, char *buf,int len, const char *param);
-int fmt_icapmethod(ci_request_t *req_data, char *buf,int len, const char *param);
-int fmt_service(ci_request_t *req_data, char *buf,int len, const char *param);
-int fmt_username(ci_request_t *req_data, char *buf,int len, const char *param);
-int fmt_request(ci_request_t *req_data, char *buf,int len, const char *param);
-int fmt_localtime(ci_request_t *req_data, char *buf,int len, const char *param);
-int fmt_gmttime(ci_request_t *req_data, char *buf,int len, const char *param);
-int fmt_seconds(ci_request_t *req_data, char *buf,int len, const char *param);
-int fmt_httpclientip(ci_request_t *req_data, char *buf,int len, const char *param);
-int fmt_httpserverip(ci_request_t *req_data, char *buf,int len, const char *param);
-int fmt_http_req_url_o(ci_request_t *req_data, char *buf,int len, const char *param);
-int fmt_http_req_head_o(ci_request_t *req_data, char *buf,int len, const char *param);
-int fmt_http_res_head_o(ci_request_t *req_data, char *buf,int len, const char *param);
-int fmt_icap_req_head(ci_request_t *req_data, char *buf,int len, const char *param);
-int fmt_icap_res_head(ci_request_t *req_data, char *buf,int len, const char *param);
-int fmt_req_bytes_rcv(ci_request_t *req_data, char *buf,int len, const char *param);
-int fmt_req_bytes_sent(ci_request_t *req_data, char *buf,int len, const char *param);
-int fmt_req_http_bytes_rcv(ci_request_t *req_data, char *buf,int len, const char *param);
-int fmt_req_http_bytes_sent(ci_request_t *req_data, char *buf,int len, const char *param);
-int fmt_req_body_bytes_rcv(ci_request_t *req_data, char *buf,int len, const char *param);
-int fmt_req_body_bytes_sent(ci_request_t *req_data, char *buf,int len, const char *param);
-int fmt_req_preview_hex(ci_request_t *req_data, char *buf,int len, const char *param);
-int fmt_req_preview_len(ci_request_t *req_data, char *buf,int len, const char *param);
-int fmt_logstr(ci_request_t *req_data, char *buf,int len, const char *param);
-int fmt_req_attribute(ci_request_t *req_data, char *buf,int len, const char *param);
-
-//
 int fmt_malware(ci_request_t *req, char *buf, int len, const char *param);
 
-
 struct ci_fmt_entry GlobalTable [] = {
-    { "%a", "Remote IP-Address", fmt_remoteip },
-    {"%la", "Local IP Address", fmt_localip },
-    {"%lp", "Local port", fmt_none},
-    {"%>a", "Http Client IP Address", fmt_httpclientip},
-    {"%<A", "Http Server IP Address", fmt_httpserverip},
-    {"%ts", "Seconds since epoch", fmt_seconds},
-    {"%tl", "Local time", fmt_localtime},
-    {"%tg", "GMT time", fmt_gmttime},
-    {"%tr", "Response time", fmt_none},
-    {"%>hi", "Http request header", fmt_none},
-    {"%>ho", "Modified Http request header", fmt_http_req_head_o},
-    {"%huo", "Modified Http request url", fmt_http_req_url_o},
-    {"%hu", "Http request url", fmt_none},
-    {"%<hi", "Http reply header", fmt_none},
-    {"%<ho", "Modified Http reply header", fmt_http_res_head_o},
-    {"%Hs", "Http reply status", fmt_none},
-    {"%Hso", "Modified Http reply status", fmt_none},
-
-    {"%iu", "Icap request url", fmt_request},
-    {"%im", "Icap method", fmt_icapmethod},
-    {"%is", "Icap status code", fmt_icapstatus},
-    {"%>ih", "Icap request header", fmt_icap_req_head},
-    {"%<ih", "Icap response header", fmt_icap_res_head},
-    {"%ipl", "Icap preview length", fmt_req_preview_len},
-
-    {"%Ih", "Http bytes received", fmt_req_http_bytes_rcv},
-    {"%Oh", "Http bytes sent", fmt_req_http_bytes_sent},
-    {"%Ib", "Http body bytes received", fmt_req_body_bytes_rcv},
-    {"%Ob", "Http body bytes sent", fmt_req_body_bytes_sent},
-
-    {"%I", "Bytes received", fmt_req_bytes_rcv},
-    {"%O", "Bytes sent", fmt_req_bytes_sent},
-
-    {"%bph", "Body data preview", fmt_req_preview_hex},
-    {"%un", "Username", fmt_username},
-    {"%Sl", "Service log string", fmt_logstr},
-    {"%Sa", "Attribute set by service", fmt_req_attribute},
-    {"%%", "% sign", fmt_percent},
-
-    // custom one just for the malware name
     {"%mn", "Malware Name", fmt_malware},
     { NULL, NULL, NULL}
 };


### PR DESCRIPTION
... so no need to duplicate them here.

I should have read the c-icap code more closely.
