### PR TITLE
clean up HTTP Response headers

### DIFF
--- a/src/squidclamav.c
+++ b/src/squidclamav.c
@@ -621,14 +621,14 @@ int squidclamav_end_of_data_handler(ci_request_t * req)
     /* SCAN DATA HERE */
     if ((sockd = dconnect ()) < 0) {
         debugs(0, "ERROR Can't connect to Clamd daemon.\n");
-        goto done_allow204;
+        return CI_MOD_ERROR;
     }
     debugs(1, "DEBUG Sending zINSTREAM command to clamd.\n");
 
     if (write(sockd, "zINSTREAM", 10) <= 0) {
         debugs(0, "ERROR Can't write to Clamd socket.\n");
         close(sockd);
-        goto done_allow204;
+        return CI_MOD_ERROR;
     }
 
     debugs(1, "DEBUG Ok connected to clamd.\n");


### PR DESCRIPTION
Some HTTP Resonse headers are not cleaned up, therefore if a virus is found in, for example, a downloadable file, it will download, but the contents of the will will be the error page html content.

If the headers are cleared properly, the error page will be displayed instead. 

Also, adding 403 Forbidden is more according to the situation thant 200 OK.
