### PR TITLE
C-icap 0.4.x replaced `hasalldata` with `flags`

### DIFF
--- a/src/squidclamav.c
+++ b/src/squidclamav.c
@@ -1562,7 +1562,7 @@ void generate_template_page(ci_request_t *req, av_req_data_t *data)
     free(malware);
 
     data->error_page = ci_txt_template_build_content(req, "squidclamav", "MALWARE_FOUND", GlobalTable);
-    data->error_page->hasalldata = 1;
+    data->error_page->flags = CI_MEMBUF_HAS_EOF;
 
     snprintf(buf, LOW_BUFF, "Content-Language: %s",
              (char *)ci_membuf_attr_get(data->error_page, "lang"));


### PR DESCRIPTION
Fixes the issue #27 