### PR TITLE
Send multipart content-type headers to clamav

### DIFF
--- a/README
+++ b/README
@@ -556,6 +556,11 @@ CONFIGURATION
         when the content-length of the file is bigger than the defined
         value. By default there's no size limit.
 
+    multipart
+        Send the Content-Type header to Clamav for multipart content types
+        so multipart bodies can be broken up by their boundary and each part
+        can be scanned.
+
   Testing SquidClamav
     As SquidClamav v6.0 is now a c-icap service, it can no more be run at
     console in interactive mode. To check what is going wrong, you must edit

--- a/doc/README
+++ b/doc/README
@@ -571,6 +571,11 @@ CONFIGURATION
         when the content-length of the file is bigger than the defined
         value. By default there's no size limit.
 
+    multipart
+        Send the Content-Type header to Clamav for multipart content types
+        so multipart bodies can be broken up by their boundary and each part
+        can be scanned.
+
   Testing SquidClamav
     As SquidClamav v6.0 is now a c-icap service, it can no more be run at
     console in interactive mode. To check what is going wrong, you must edit

--- a/etc/squidclamav.conf
+++ b/etc/squidclamav.conf
@@ -48,6 +48,11 @@ dnslookup 1
 # virus scan request. 
 safebrowsing 0
 
+# Send the Content-Type header to Clamav for multipart content types
+# so multipart bodies can be broken up by their boundary and each part
+# can be scanned.
+multipart 0
+
 #
 # Here is some defaut regex pattern to have a high speed proxy on system
 # with low resources.


### PR DESCRIPTION
clamd supports decoding email style multipart content and virus scanning each part.
Unless clamd receives a Content-Type header it can't know how to break up the multipart content. and so it tries to scan the entire body as one file, even if parts are base64 encoded etc.
This PR attempts to detect multipart content and sends a To: and Content-Type header through to clamd before the rest of the body.
I have put this behind a config option that defaults to off.
