### PR TITLE
Fix typos/translation error

### DIFF
--- a/cgi-bin/clwarn.cgi
+++ b/cgi-bin/clwarn.cgi
@@ -25,7 +25,7 @@ my $errorreturn = 'This file cannot be downloaded.';
 my $urlerror = 'contains a threat';
 if ($virus =~ /Safebrowsing/) {
 	$TITLE_VIRUS = "SquidClamAv $VERSION: Unsafe Browsing detected";
-	$subtitle = 'Malware / pishing type';
+	$subtitle = 'Malware / phishing type';
 	$urlerror = 'is listed as suspicious';
 	$errorreturn = 'This page can not be displayed';
 }

--- a/cgi-bin/clwarn.cgi.en_EN
+++ b/cgi-bin/clwarn.cgi.en_EN
@@ -25,7 +25,7 @@ my $errorreturn = 'This file cannot be downloaded.';
 my $urlerror = 'contains a threat';
 if ($virus =~ /Safebrowsing/) {
 	$TITLE_VIRUS = "SquidClamAv $VERSION: Unsafe Browsing detected";
-	$subtitle = 'Malware / pishing type';
+	$subtitle = 'Malware / phishing type';
 	$urlerror = 'is listed as suspicious';
 	$errorreturn = 'This page can not be displayed';
 }

--- a/cgi-bin/clwarn.cgi.ru_RU
+++ b/cgi-bin/clwarn.cgi.ru_RU
@@ -18,8 +18,8 @@ my $recover = CGI::escapeHTML($cgi->param('recover')) || '';
 $recover =~ s/^\(null\)$//;
 my $default_recoverurl = 'https://' . $cgi->server_name() . "/recover/?id=" if ($recover);
 
-my $TITLE_VIRUS = "SquidClamAv $VERSION: Обнаружен угроза!";
-my $subtitle = 'Имя угроза';
+my $TITLE_VIRUS = "SquidClamAv $VERSION: Обнаружена угроза!";
+my $subtitle = 'Имя угрозы';
 my $errorreturn = 'Этот файл не может быть загружен.';
 my $urlerror = 'содержит угроза';
 if ($virus =~ /Safebrowsing/) {

--- a/cgi-bin/clwarn.cgi.ru_RU
+++ b/cgi-bin/clwarn.cgi.ru_RU
@@ -21,10 +21,10 @@ my $default_recoverurl = 'https://' . $cgi->server_name() . "/recover/?id=" if (
 my $TITLE_VIRUS = "SquidClamAv $VERSION: Обнаружена угроза!";
 my $subtitle = 'Имя угрозы';
 my $errorreturn = 'Этот файл не может быть загружен.';
-my $urlerror = 'содержит угроза';
+my $urlerror = 'содержит угрозу';
 if ($virus =~ /Safebrowsing/) {
 	$TITLE_VIRUS = "SquidClamAv $VERSION: Unsafe Browsing detected";
-	$subtitle = 'Malware / pishing type';
+	$subtitle = 'Malware / phishing type';
 	$urlerror = 'занесен в список подозрительных';
 	$errorreturn = 'Эта страница не может быть отображена';
 }


### PR DESCRIPTION
RU warning contains translation errors. Also, old typo at EN warn pages (omitted h).