### PR TITLE
Create http response entity if not present in icap request

### DIFF
--- a/src/squidclamav.c
+++ b/src/squidclamav.c
@@ -1893,6 +1893,8 @@ void generate_template_page(ci_request_t *req, av_req_data_t *data)
 
     if ( ci_http_response_headers(req))
 	ci_http_response_reset_headers(req);
+    else
+       ci_http_response_create(req, 1, 1);
     ci_http_response_add_header(req, "HTTP/1.0 403 Forbidden");
     ci_http_response_add_header(req, "Server: C-ICAP");
     ci_http_response_add_header(req, "Connection: close");


### PR DESCRIPTION
If a virus is detected in http request payload itself, http response entity was null hence subsequent updates to this entity was not happening. That's why error page was getting sent to server instead of to the client.

It solves the issue mentioned in #22 . 