### PR TITLE
Add a JP translation for clwarn.cgi

### DIFF
--- a/cgi-bin/clwarn.cgi.ja_JP
+++ b/cgi-bin/clwarn.cgi.ja_JP
@@ -1,0 +1,104 @@
+#!/usr/bin/perl
+use strict;
+
+use CGI;
+
+my $VERSION = '7.2';
+
+my $cgi = new CGI;
+
+my $url = CGI::escapeHTML(scalar $cgi->param('url')) || '';
+my $virus = CGI::escapeHTML(scalar $cgi->param('virus')) || CGI::escapeHTML(scalar $cgi->param('malware')) || '';
+my $source = CGI::escapeHTML(scalar $cgi->param('source')) || '';
+$source =~ s/\/-//;
+my $user = CGI::escapeHTML(scalar $cgi->param('user')) || '';
+
+# libarchive support:
+my $recover = CGI::escapeHTML(scalar $cgi->param('recover')) || '';
+$recover =~ s/^\(null\)$//;
+my $default_recoverurl = 'https://' . $cgi->server_name() . "/recover/?id=" if ($recover);
+
+
+my $TITLE_VIRUS = "SquidClamAv $VERSION: 脅威を発見！";
+my $subtitle = '脅威名';
+my $errorreturn = 'このファイルをダウンロードすることはできません。';
+#my $urlerror = 'contains a threat';
+my $requested = sprintf("要求されたURL %s 脅威が含まれています", $url);
+if ($virus =~ /Safebrowsing/) {
+	$TITLE_VIRUS = "SquidClamAv $VERSION: 安全ではないブラウジングを検出しました";
+	$subtitle = 'マルウェア / フィッシングタイプ';
+	#$urlerror = 'is listed as suspicious';
+	$requested = sprintf("要求されたURL %s は疑わしいものとして記載されています", $url);
+	$errorreturn = 'このページを表示することはできません';
+}
+
+# Remove clamd infos
+$virus =~ s/stream: //;
+$virus =~ s/ FOUND//;
+
+
+print $cgi->header();
+
+print $cgi->start_html(-title => $TITLE_VIRUS, -bgcolor => "#353535");
+print qq{
+<style type="text/css">
+.visu {
+	border:1px solid #C0C0C0;
+	color:#FFFFFF;
+	position: relative;
+	min-width: 13em;
+	max-width: 52em;
+	margin: 4em auto;
+	border: 1px solid ThreeDShadow;
+	border-radius: 10px;
+	padding: 3em;
+	-moz-padding-start: 30px;
+	background-color: #8b0000;
+}
+.visu h2, .visu h3, .visu h4 {
+	font-size:130%;
+	font-family:"times new roman", times, serif;
+	font-style:normal;
+	font-weight:bolder;
+}
+.visu a:link, a:visited, a:active {
+	text-decoration: none;
+	color:#FFFFFF;
+}
+.visu a:hover {
+	text-decoration: none;
+	color:#00FF00;
+}
+</style>	
+	<div class="visu">
+	<h2>$TITLE_VIRUS</h2>
+	<hr>
+	<p>
+};
+print qq{
+	$requested<br>
+	$subtitle: $virus
+};
+
+print qq{
+	<p>
+	$errorreturn
+	<p>
+	起源: $source / $user
+};
+
+print qq{
+	<p>
+	回復：<a target="_blank" href="$default_recoverurl$recover">データを回復するためのリンク</a>
+} if ($recover);
+
+print qq{
+	<p>
+	<hr>
+	<font color="blue"> 搭載 <a href="http://squidclamav.darold.net/">SquidClamAv $VERSION</a>.</font>
+	</div>
+};
+
+print $cgi->end_html();
+
+exit 0;


### PR DESCRIPTION
Note, this was initially taken from a thrid-party build and then added to my COPR build.
Much of the translation was done by Google Translate, but it does seem to be correct.