### PR TITLE
Patch for GCC15 issues - BZ2341381

### DIFF
--- a/src/squidclamav.c
+++ b/src/squidclamav.c
@@ -2144,7 +2144,7 @@ int dconnect()
     return 0;
 }
 
-void connect_timeout()
+void connect_timeout(int sig)
 {
     // doesn't actually need to do anything
 }


### PR DESCRIPTION
The mass rebuild for Fedora 42, with the recently released GCC 15 compiler generated build errors, this is a patch to fix them.

The issues were all Function declarations without parameters (see [https://gcc.gnu.org/gcc-15/porting_to.html](https://gcc.gnu.org/gcc-15/porting_to.html)) and kind of trivial fixes.